### PR TITLE
Use `with` to automatically close file

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,9 +25,8 @@ with open('posts/your_posts_1.json','r') as f:
 
 print(postString)
 
-sample = open("data.txt", "r", errors="ignore")
-data = sample.read()
-sample.close()
+with open("data.txt", "r", errors="ignore") as sample:
+    data = sample.read()
 
 data = (data
     .lower()


### PR DESCRIPTION
The pattern of 

```python
file = open("path", "r")
# ... do stuff with file ...
file.close()
```

Is subtly flawed in that if an error happens between opening the file and closing it, you will never reach the line that closes the file. This doesn't matter if the next thing your code does is crash entirely, but if you have a longer running app (like a web server) then this would be a "resource leak"

When you do

```python
with open("path", "r") as file:
    # ... do stuff with file ...
```

Then no matter what happens, Python will close the file when you exit that block